### PR TITLE
Omit Linux distro and version for 32 bit Linux downloads

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function (opts, cb) {
 
 	var name = "mongodb-" + mongo_platform + "-" + mongo_arch;
 
-	if ( mongo_platform === "linux" ) {
+	if ( mongo_platform === "linux" && mongo_arch !== "i686" ) {
 		// append distro
 		getos(function(e, os) {
 			if(e) {


### PR DESCRIPTION
32-bit MongoDB versions does not contain Linux distro and version in its filename:
https://fastdl.mongodb.org/linux/mongodb-linux-i686-3.2.0.tgz 

Was trying to test Mockgoose and mongodb-download would download "mongodb-linux-i686-ubuntu1404-3.2.0.tgz" which didn't actually exist. This may also resolve #6 for some people if they're on 32-bit.
