### PR TITLE
fix(Ubuntu): Travis CI with Ubuntu may not return `os.release`

### DIFF
--- a/src/mongodb-download.ts
+++ b/src/mongodb-download.ts
@@ -562,7 +562,7 @@ export class MongoDBPlatform {
   
   getUbuntuVersionString(os: any): string {
     let name: string = "ubuntu";
-    let ubuntu_version: string[] = os.release.split('.');
+    let ubuntu_version: string[] = os.release ? os.release.split('.') : '';
     let major_version: number = parseInt(ubuntu_version[0]);
     let minor_version: string = ubuntu_version[1];
 


### PR DESCRIPTION
My build fails with such error:
```
TypeError: Cannot read property 'split' of undefined
    at MongoDBPlatform.Object.<anonymous>.MongoDBPlatform.getUbuntuVersionString (/home/travis/build/nodkz/graphql-compose-mongoose/node_modules/mongodb-download/built/mongodb-download.js:526:40)
    at /home/travis/build/nodkz/graphql-compose-mongoose/node_modules/mongodb-download/built/mongodb-download.js:444:35
    at /home/travis/build/nodkz/graphql-compose-mongoose/node_modules/getos/index.js:100:16
    at /home/travis/build/nodkz/graphql-compose-mongoose/node_modules/async/dist/async.js:356:16
    at iteratorCallback (/home/travis/build/nodkz/graphql-compose-mongoose/node_modules/async/dist/async.js:936:13)
    at /home/travis/build/nodkz/graphql-compose-mongoose/node_modules/async/dist/async.js:840:16
    at /home/travis/build/nodkz/graphql-compose-mongoose/node_modules/getos/index.js:95:18
    at /home/travis/build/nodkz/graphql-compose-mongoose/node_modules/async/dist/async.js:3025:16
    at eachOfArrayLike (/home/travis/build/nodkz/graphql-compose-mongoose/node_modules/async/dist/async.js:941:9)
    at eachOf (/home/travis/build/nodkz/graphql-compose-mongoose/node_modules/async/dist/async.js:991:5)
    at Object.eachLimit (/home/travis/build/nodkz/graphql-compose-mongoose/node_modules/async/dist/async.js:3089:3)
    at /home/travis/build/nodkz/graphql-compose-mongoose/node_modules/getos/index.js:80:13
    at tryToString (fs.js:456:3)
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:443:12)
```

Broken build: https://travis-ci.org/nodkz/graphql-compose-mongoose/jobs/239961050

This PR fix this problem.
Closes #16 