### PR TITLE
naive fix for debian 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ node_modules
 *.log
 *.swp
 *.swo
-
-built/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 *.log
 *.swp
 *.swo
+
+built/

--- a/src/mongodb-download.ts
+++ b/src/mongodb-download.ts
@@ -9,7 +9,7 @@ const decompress: any = require('decompress');
 const request: any = require('request-promise');
 const md5File: any = require('md5-file');
 
-const DOWNLOAD_URI: string = "https://fastdl.mongodb.org";
+const DOWNLOAD_URI: string = "https://www.mongodb.org/dl/linux/";
 const MONGODB_VERSION: string = "latest";
 
 export interface IMongoDBDownloadOptions {

--- a/src/mongodb-download.ts
+++ b/src/mongodb-download.ts
@@ -514,7 +514,7 @@ export class MongoDBPlatform {
   
   getDebianVersionString(os: any): string {
     let name: string = "debian";
-    if (/^(7|8)/.test(os.release)) {
+    if (/^[7-9]+/.test(os.release)) {
       name += "71";
     } else {
       this.debug("using legacy release");

--- a/src/mongodb-download.ts
+++ b/src/mongodb-download.ts
@@ -511,10 +511,13 @@ export class MongoDBPlatform {
       });
     });    
   }
-  
+
   getDebianVersionString(os: any): string {
     let name: string = "debian";
-    if (/^[7-9]+/.test(os.release)) {
+    let release: number = parseFloat(os.release);
+    if (release >= 8.1) {
+      name += "81";
+    } else if (release >= 7.1) {
       name += "71";
     } else {
       this.debug("using legacy release");

--- a/src/mongodb-download.ts
+++ b/src/mongodb-download.ts
@@ -9,7 +9,7 @@ const decompress: any = require('decompress');
 const request: any = require('request-promise');
 const md5File: any = require('md5-file');
 
-const DOWNLOAD_URI: string = "https://www.mongodb.org/dl/linux/";
+const DOWNLOAD_URI: string = "https://fastdl.mongodb.org";
 const MONGODB_VERSION: string = "latest";
 
 export interface IMongoDBDownloadOptions {

--- a/test/MongoDBPlatform-DebianTest.js
+++ b/test/MongoDBPlatform-DebianTest.js
@@ -1,0 +1,52 @@
+const expect = require('chai').expect;
+
+let {MongoDBPlatform} = require('../built/mongodb-download.js');
+
+
+describe('MongoDBPlatform class', () => {
+
+    describe('getDebianVersionString()', () => {
+
+        const mongoDBDownload = new MongoDBPlatform("linux", "x64");
+
+        let os = {
+            dist: "debian",
+        };
+
+        it('should return a archive name for debian 6.2', done => {
+            os.release = "6.2";
+            expect(mongoDBDownload.getDebianVersionString(os)).to.equal("debian");
+            done();
+        });
+
+        it('should return a archive name for debian 7.0', done => {
+            os.release = "7.0";
+            expect(mongoDBDownload.getDebianVersionString(os)).to.equal("debian");
+            done();
+        });
+
+        it('should return a archive name for debian 7.1', done => {
+            os.release = "7.1";
+            expect(mongoDBDownload.getDebianVersionString(os)).to.equal("debian71");
+            done();
+        });
+
+        it('should return a archive name for debian 8.0', done => {
+            os.release = "8.0";
+            expect(mongoDBDownload.getDebianVersionString(os)).to.equal("debian71");
+            done();
+        });
+
+        it('should return a archive name for debian 8.1', done => {
+            os.release = "8.1";
+            expect(mongoDBDownload.getDebianVersionString(os)).to.equal("debian81");
+            done();
+        });
+
+        it('should return a archive name for debian 9.0', done => {
+            os.release = "9.0";
+            expect(mongoDBDownload.getDebianVersionString(os)).to.equal("debian81");
+            done();
+        });
+    })
+});


### PR DESCRIPTION
The mongo package does not exist for debian 9.
I changed the regexp to use 71 (as for version 7 and 8) instead of legacy