### PR TITLE
Fix #23

### DIFF
--- a/src/mongodb-download.ts
+++ b/src/mongodb-download.ts
@@ -318,7 +318,11 @@ export class MongoDBDownload {
         
         fileStream.on('finish', () => {
           fileStream.close(() => {
-            fs.renameSync(tempDownloadLocation, downloadLocation);
+            try {
+              fs.renameSync(tempDownloadLocation, downloadLocation);
+            } catch (err) {
+              this.debug(`The error was thrown while trying to rename: ${err}`);
+            }
             this.debug(`renamed ${tempDownloadLocation} to ${downloadLocation}`);
             resolve(downloadLocation);
           });


### PR DESCRIPTION
This PR fixes the issue #23. It makes so that when the renaming fails, the
thrown error only gets printed as the debug message.