### PR TITLE
Fix UnhandledPromiseRejectionWarning error

### DIFF
--- a/src/mongodb-download.ts
+++ b/src/mongodb-download.ts
@@ -9,7 +9,7 @@ const decompress: any = require('decompress');
 const request: any = require('request-promise');
 const md5File: any = require('md5-file');
 
-const DOWNLOAD_URI: string = "http://downloads.mongodb.org";
+const DOWNLOAD_URI: string = "https://downloads.mongodb.org";
 const MONGODB_VERSION: string = "latest";
 
 export interface IMongoDBDownloadOptions {


### PR DESCRIPTION
Using __http__://downloads.mongodb.org rejects with an error:

```
(node:21921) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 7): Error: Protocol "http:" not supported. Expected "https:"
```