### PR TITLE
Support for downloading Mongo in Debian >=9.2

### DIFF
--- a/built/mongodb-download.js
+++ b/built/mongodb-download.js
@@ -474,7 +474,10 @@ var MongoDBPlatform = (function () {
     MongoDBPlatform.prototype.getDebianVersionString = function (os) {
         var name = "debian";
         var release = parseFloat(os.release);
-        if (release >= 8.1) {
+        if (release >= 9.2) {
+            name += "92";
+        }
+        else if (release >= 8.1) {
             name += "81";
         }
         else if (release >= 7.1) {


### PR DESCRIPTION
As reported in:

[Mockgoose Issue #46](https://github.com/Mockgoose/Mockgoose/issues/46)
[mongodb-download Issue #30](https://github.com/winfinit/mongodb-download/issues/30)

The actual code doesn't support Debian 9 distribution
I could fix in a simple way adding a new alternative for the URL creation, this solution has been tested and works for me

PD: Sorry for the coding style fixes, my editor does this by default

Fixes #30 